### PR TITLE
[bugzid:2554] Fixed NPE on network creation

### DIFF
--- a/src/main/java/org/dasein/cloud/azure/network/AzureVlanSupport.java
+++ b/src/main/java/org/dasein/cloud/azure/network/AzureVlanSupport.java
@@ -358,8 +358,13 @@ public class AzureVlanSupport extends AbstractVLANSupport {
 
                 NodeList virtualNetworkSites = element.getElementsByTagName("VirtualNetworkSites");
                 Node item = virtualNetworkSites.item(0);
-
-                Element elItem = (Element) item;
+                Element elItem;
+                if (item == null) {
+                    elItem = doc.createElement("VirtualNetworkSites");
+                    element.appendChild(elItem);
+                } else {
+                    elItem = (Element) item;
+                }
 
                 Element vns = doc.createElement("VirtualNetworkSite");
                 vns.setAttribute("name", name);


### PR DESCRIPTION
The NetworkConfiguration can return non-empty but without a VirtualNetworkSites in VirtualNetworkConfiguration. This patch creates one in that situation.
