### PR TITLE
Prevent possible Azure error if storageEndpoint is empty

### DIFF
--- a/src/main/java/org/dasein/cloud/azure/Azure.java
+++ b/src/main/java/org/dasein/cloud/azure/Azure.java
@@ -155,6 +155,7 @@ public class Azure extends AbstractCloud {
             }
 
             if( storageEndpoint == null || storageEndpoint.isEmpty()) {
+                storageEndpoint = null;
                 throw new CloudException("Cannot find blob storage endpoint in the current region");
             }
         }


### PR DESCRIPTION
If storageEndpoint is blank, the exception is thrown the first time, but after that the earlier null check is bypassed and an empty string is returned. This results in Azure complaining, during VM launch, about a mediaLink value that is not an absolute URL.
