### PR TITLE
Reset storage endpoint to null on error

### DIFF
--- a/src/main/java/org/dasein/cloud/azure/Azure.java
+++ b/src/main/java/org/dasein/cloud/azure/Azure.java
@@ -155,6 +155,7 @@ public class Azure extends AbstractCloud {
             }
 
             if( storageEndpoint == null || storageEndpoint.isEmpty()) {
+                storageEndpoint = null;
                 throw new CloudException("Cannot find blob storage endpoint in the current region");
             }
         }


### PR DESCRIPTION
Reset endpoint to null so that the second time through the method doesn't return an empty string causing issues later on.
