### PR TITLE
Avoid an NPE when image class not set in filter options

### DIFF
--- a/src/main/java/org/dasein/cloud/azure/compute/image/AzureOSImage.java
+++ b/src/main/java/org/dasein/cloud/azure/compute/image/AzureOSImage.java
@@ -355,7 +355,7 @@ public class AzureOSImage extends AbstractImageSupport {
     @Nonnull
     @Override
     public Iterable<MachineImage> listImages(@Nullable ImageFilterOptions imageFilterOptions) throws CloudException, InternalException {
-        if (!imageFilterOptions.getImageClass().equals(ImageClass.MACHINE)) {
+        if (imageFilterOptions.getImageClass() != null && !imageFilterOptions.getImageClass().equals(ImageClass.MACHINE)) {
             return Collections.emptyList();
         }
 


### PR DESCRIPTION
If a pass a default filter options object to listImages() I end up with a NPE because the code was assuming that image class would always be set. The patch assumes that if image class is not set that no filter will be done because of the image class (e.g. all image classes will be returned, which in the case of Azure, is only the machine image class).
