### PR TITLE
[bugzid:4759] Switched to finding subnets by name rather than ID to fix removal

### DIFF
--- a/src/main/java/org/dasein/cloud/azure/network/AzureVlanSupport.java
+++ b/src/main/java/org/dasein/cloud/azure/network/AzureVlanSupport.java
@@ -772,7 +772,7 @@ public class AzureVlanSupport extends AbstractVLANSupport {
                             if( subnetName.equalsIgnoreCase("Subnet") && vn.hasChildNodes() ) {
                                 Element sub = (Element) subnetNode;
                                 String subName = sub.getAttribute("name");
-                                if (subName.equalsIgnoreCase(providerSubnetId)) {
+                                if (subName.equalsIgnoreCase(subnet.getName())) {
                                     subnetsEl.removeChild(subnetNode);
                                 }
                             }


### PR DESCRIPTION
I think this fixes https://enstratus.fogbugz.com/default.asp?4759 but I'd like someone from the Dasein team to double check this.
