### PR TITLE
Enable setting of Linux user name from launch options

### DIFF
--- a/src/main/java/org/dasein/cloud/azure/compute/vm/AzureVM.java
+++ b/src/main/java/org/dasein/cloud/azure/compute/vm/AzureVM.java
@@ -583,7 +583,9 @@ public class AzureVM extends AbstractVMSupport {
                     xml.append("<HostName>").append(hostName).append("</HostName>");
 
                     //dmayne using root causes vm to fail provisioning
-                    xml.append("<UserName>dasein</UserName>");
+                    String username = (options.getBootstrapUser() == null || options.getBootstrapUser().trim().length() == 0 || options.getBootstrapUser().equals("root") 
+                          ? "dasein" : options.getBootstrapUser());
+                    xml.append("<UserName>").append(username).append("</UserName>");
                     xml.append("<UserPassword>").append(password).append("</UserPassword>");
                     xml.append("<DisableSshPasswordAuthentication>false</DisableSshPasswordAuthentication>");
                     xml.append("</ConfigurationSet>");


### PR DESCRIPTION
Seems like it would be a good idea to use the bootstrap user name provided in the VMLaunch options when creating a username for Linux, rather than hard-coding "dasein" (though that is still the default).
