### PR TITLE
Avoid NPE if no image class provided in filter options.

### DIFF
--- a/src/main/java/org/dasein/cloud/azure/compute/image/AzureOSImage.java
+++ b/src/main/java/org/dasein/cloud/azure/compute/image/AzureOSImage.java
@@ -355,7 +355,7 @@ public class AzureOSImage extends AbstractImageSupport {
     @Nonnull
     @Override
     public Iterable<MachineImage> listImages(@Nullable ImageFilterOptions imageFilterOptions) throws CloudException, InternalException {
-        if (!imageFilterOptions.getImageClass().equals(ImageClass.MACHINE)) {
+        if (imageFilterOptions.getImageClass() != null && !imageFilterOptions.getImageClass().equals(ImageClass.MACHINE)) {
             return Collections.emptyList();
         }
 


### PR DESCRIPTION
The earlier patch I supplied to test for a null image class was not forwarded to the develop branch, so the problem showed up in 2014.08 branch again.
