### PR TITLE
changes for terminate VM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>org.dasein</groupId>
             <artifactId>dasein-cloud-test</artifactId>
-            <version>2014.11.1</version>
+            <version>2014.11.2-SNAPSHOT</version>
             <scope>test</scope>
             <optional>false</optional>
         </dependency>

--- a/src/main/java/org/dasein/cloud/azure/AzureMethod.java
+++ b/src/main/java/org/dasein/cloud/azure/AzureMethod.java
@@ -636,6 +636,9 @@ public class AzureMethod {
             else if(httpMethod instanceof HttpDelete && url.indexOf("services/vmimages") > -1 ){
                 httpMethod.addHeader("x-ms-version", "2014-06-01");
             }
+            else if(httpMethod instanceof HttpDelete && url.contains("deployments") && url.endsWith("?comp=media")){
+                httpMethod.addHeader("x-ms-version", "2013-08-01");
+            }
             else {
                 httpMethod.addHeader("x-ms-version", "2012-03-01");
             }

--- a/src/main/java/org/dasein/cloud/azure/compute/vm/AzureRoleDetails.java
+++ b/src/main/java/org/dasein/cloud/azure/compute/vm/AzureRoleDetails.java
@@ -1,0 +1,51 @@
+package org.dasein.cloud.azure.compute.vm;
+
+/**
+ * Created by vmunthiu on 12/11/2014.
+ */
+public class AzureRoleDetails{
+    private String serviceName;
+    private String deploymentName;
+    private String roleName;
+
+    private AzureRoleDetails(String serviceName, String deploymentName, String roleName){
+        this.serviceName = serviceName;
+        this.deploymentName = deploymentName;
+        this.roleName = roleName;
+    }
+
+    public static AzureRoleDetails fromString(String id){
+        String[] parts = id.split(":");
+        String serviceName, deploymentName, roleName;
+
+        if (parts.length == 3)    {
+            serviceName = parts[0];
+            deploymentName = parts[1];
+            roleName= parts[2];
+        }
+        else if( parts.length == 2 ) {
+            serviceName = parts[0];
+            deploymentName = parts[1];
+            roleName = serviceName;
+        }
+        else {
+            serviceName = id;
+            deploymentName = id;
+            roleName = id;
+        }
+
+        return new AzureRoleDetails(serviceName, deploymentName, roleName);
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getDeploymentName() {
+        return deploymentName;
+    }
+
+    public String getRoleName() {
+        return roleName;
+    }
+}


### PR DESCRIPTION
changed API calls for vmrole/deployment deletion to use comp=media
fixed terminate method: if only one VM in deployment delete whole deployment if more roles present delete only required VM
fixed getVirtualMachine to check for role name too.
